### PR TITLE
Inversione quiz in Magma

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,6 @@ interface Magma<A> {
 
 Abbiamo quindi un'operazione `concat` che prende due valori di un certo tipo `A` e restituisce un nuovo valore dello stesso tipo (proprietà di chiusura). Dato che il risultato può a sua volta essere utilizzato come input l'operazione può essere ripetuta a piacimento. In altre parole `concat` è un [combinatore](#composizione) per il tipo `A`.
 
-**Quiz**. Il fatto che una operazione sia chiusa non è una proprietà banale, potete fare un esempio di operazione sui numeri naturali (ovvero i numeri interi positivi) per cui la proprietà di chiusura non vale?
-
 Per avere una istanza concreta di magma per un determinato tipo occorre perciò definire un oggetto conforme a questa interfaccia.
 
 **Esempio** (una istanza di `Magma` per il tipo `number`)
@@ -307,6 +305,8 @@ pipe(10, concat(2), concat(3), concat(1), concat(2), console.log)
 ```
 
 Notate che la definizione di `concat` è stata concepita per agevolarne l'uso con `pipe`.
+
+**Quiz**. Il fatto che una operazione sia chiusa non è una proprietà banale. Sarebbe stato possibile definire un magma con la stessa operazione `concat` di `MagmaSub` sui numeri naturali (ovvero i numeri interi positivi) anzichè usando `number`? Potete fare un altro esempio di operazione sui numeri naturali per cui la proprietà di chiusura non vale? 
 
 **Quiz**. Consideriamo la seguente funzione che trasforma una lista in un dizionario, perché si richiede un `Magma` come parametro?
 


### PR DESCRIPTION
Secondo me prima di vedere operazioni che non rispettino la proprieta` di chiusura sarebbe utile vederne una che la rispetta.

La prima domanda offre l'occasione di riflettere sulla stessa operazione, sottrazione, e vedendo come la chiusura non e' rispettata al cambio del tipo (razionali vs naturali).

La seconda offre l'occasione di mantenere il tipo (naturali) ma di dover pensare ad altre operazioni (esempio: divisione) che non formano un magma.